### PR TITLE
Allow short-lived AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Create a secret for irsa-manager to access AWS:
 kubectl create secret generic aws-secret -n irsa-manager-system \
   --from-literal=aws-access-key-id=<your-access-key-id> \
   --from-literal=aws-secret-access-key=<your-secret-access-key> \
+  --from-literal=aws-session-token=<your-aws-session-token> # Optional \
   --from-literal=aws-region=<your-region> \
   --from-literal=aws-role-arn=<your-role-arn>  # Optional: Set this if you want to switch roles
 

--- a/charts/irsa-manager/README.md
+++ b/charts/irsa-manager/README.md
@@ -22,6 +22,7 @@ helm install irsa-manager kkb0318/irsa-manager -n irsa-manager-system --create-n
 kubectl create secret generic aws-secret -n irsa-manager-system \
   --from-literal=aws-access-key-id=<your-access-key-id> \
   --from-literal=aws-secret-access-key=<your-secret-access-key> \
+  --from-literal=aws-session-token=<your-aws-session-token> # Optional \
   --from-literal=aws-region=<your-region> \
   --from-literal=aws-role-arn=<your-role-arn>  # Optional: Set this if you want to switch roles
 

--- a/charts/irsa-manager/README.md.gotmpl
+++ b/charts/irsa-manager/README.md.gotmpl
@@ -22,6 +22,7 @@ helm install irsa-manager kkb0318/irsa-manager -n irsa-manager-system --create-n
 kubectl create secret generic aws-secret -n irsa-manager-system \
   --from-literal=aws-access-key-id=<your-access-key-id> \
   --from-literal=aws-secret-access-key=<your-secret-access-key> \
+  --from-literal=aws-session-token=<your-aws-session-token> # Optional \
   --from-literal=aws-region=<your-region> \
   --from-literal=aws-role-arn=<your-role-arn>  # Optional: Set this if you want to switch roles
 

--- a/charts/irsa-manager/templates/deployment.yaml
+++ b/charts/irsa-manager/templates/deployment.yaml
@@ -37,6 +37,11 @@ spec:
             secretKeyRef:
               key: aws-secret-access-key
               name: aws-secret
+        - name: AWS_SESSION_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: aws-session-token
+              name: aws-secret
         - name: AWS_REGION
           valueFrom:
             secretKeyRef:

--- a/charts/irsa-manager/templates/deployment.yaml
+++ b/charts/irsa-manager/templates/deployment.yaml
@@ -32,21 +32,25 @@ spec:
             secretKeyRef:
               key: aws-access-key-id
               name: aws-secret
+              optional: true
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:
               key: aws-secret-access-key
               name: aws-secret
+              optional: true
         - name: AWS_SESSION_TOKEN
           valueFrom:
             secretKeyRef:
               key: aws-session-token
               name: aws-secret
+              optional: true
         - name: AWS_REGION
           valueFrom:
             secretKeyRef:
               key: aws-region
               name: aws-secret
+              optional: true
         - name: AWS_ROLE_ARN
           valueFrom:
             secretKeyRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,25 +52,25 @@ spec:
                 secretKeyRef:
                   name: aws-secret
                   key: aws-access-key-id
-                  # optional: true
+                  optional: true
             - name: AWS_SECRET_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: aws-secret
                   key: aws-secret-access-key
-                  # optional: true
+                  optional: true
             - name: AWS_SESSION_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: aws-secret
                     key: aws-session-token
-                    # optional: true
+                    optional: true
             - name: AWS_REGION
               valueFrom:
                 secretKeyRef:
                   name: aws-secret
                   key: aws-region
-                  # optional: true
+                  optional: true
             - name: AWS_ROLE_ARN
               valueFrom:
                 secretKeyRef:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,6 +59,12 @@ spec:
                   name: aws-secret
                   key: aws-secret-access-key
                   # optional: true
+            - name: AWS_SESSION_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: aws-secret
+                    key: aws-session-token
+                    # optional: true
             - name: AWS_REGION
               valueFrom:
                 secretKeyRef:

--- a/internal/aws/aws.go
+++ b/internal/aws/aws.go
@@ -122,12 +122,20 @@ func (a *AwsS3Client) PutObjectPublic(ctx context.Context, input ObjectInput) er
 func (a *AwsS3Client) CreateBucketPublic(ctx context.Context) error {
 	log.Printf("creating S3 bucket... Name: %s, Region: %s \n", a.bucketName, a.Region())
 	bucket := aws.String(a.bucketName)
-	_, err := a.Client.CreateBucket(ctx, &s3.CreateBucketInput{
-		Bucket: bucket,
-		CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
-			LocationConstraint: s3types.BucketLocationConstraint(a.Region()),
-		},
-	})
+	var input *s3.CreateBucketInput
+	if a.Region() == "us-east-1" {
+		input = &s3.CreateBucketInput{
+			Bucket: bucket,
+		}
+	} else {
+		input = &s3.CreateBucketInput{
+			Bucket: bucket,
+			CreateBucketConfiguration: &s3types.CreateBucketConfiguration{
+				LocationConstraint: s3types.BucketLocationConstraint(a.Region()),
+			},
+		}
+	}
+	_, err := a.Client.CreateBucket(ctx, input)
 	if err != nil {
 		var bucketAlreadyOwnedByYou *s3types.BucketAlreadyOwnedByYou
 		if errors.As(err, &bucketAlreadyOwnedByYou) {

--- a/internal/controller/irsasetup_controller.go
+++ b/internal/controller/irsasetup_controller.go
@@ -88,11 +88,11 @@ func (r *IRSASetupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	defer func() {
-		if err := r.Get(ctx, req.NamespacedName, &irsav1alpha1.IRSASetup{}); err != nil {
+		if e := r.Get(ctx, req.NamespacedName, &irsav1alpha1.IRSASetup{}); e != nil {
 			return
 		}
 		statusHandler := handler.NewStatusHandler(kubeClient)
-		if err := statusHandler.Patch(ctx, obj); err != nil {
+		if e := statusHandler.Patch(ctx, obj); e != nil {
 			return
 		}
 	}()


### PR DESCRIPTION
Add SESSION_TOKEN to aws-secret and the pod
environment. (Fixes #3)
