### PR TITLE
enable proxy for offline clusters

### DIFF
--- a/charts/irsa-manager/templates/deployment.yaml
+++ b/charts/irsa-manager/templates/deployment.yaml
@@ -50,6 +50,20 @@ spec:
               optional: true
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
+        {{- if .Values.proxy.enabled }}
+        {{- if .Values.proxy.httpProxy }}
+        - name: HTTP_PROXY
+          value: {{ .Values.proxy.httpProxy | quote }}
+        {{- end }}
+        {{- if .Values.proxy.httpsProxy }}
+        - name: HTTPS_PROXY
+          value: {{ .Values.proxy.httpsProxy | quote }}
+        {{- end }}
+        {{- if .Values.proxy.noProxy }}
+        - name: NO_PROXY
+          value: {{ .Values.proxy.noProxy | quote }}
+        {{- end }}
+      {{- end }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag
           | default .Chart.AppVersion }}
         livenessProbe:

--- a/charts/irsa-manager/values.yaml
+++ b/charts/irsa-manager/values.yaml
@@ -28,3 +28,9 @@ metricsService:
     protocol: TCP
     targetPort: https
   type: ClusterIP
+proxy:
+  enabled: false
+  httpProxy: "<your_proxy>"
+  httpsProxy: "<your_proxy>"
+  noProxy: "localhost,127.0.0.1,<other_ip>"
+


### PR DESCRIPTION
i have on-prem clusters with no internet access. setting up irsa-manager requires internet access.
added proxy configuration.